### PR TITLE
chore: remove pnpm version specification in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.14.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
- Eliminated the specific pnpm version in the release.yml workflow to allow for automatic updates to the latest version.