### PR TITLE
feat: support gemini

### DIFF
--- a/.changeset/bright-regions-serve.md
+++ b/.changeset/bright-regions-serve.md
@@ -1,0 +1,5 @@
+---
+"git-pr-ai": minor
+---
+
+Add support for gemini

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A tool to automatically extract JIRA ticket numbers from branch names and create
 - 📋 Automatically create PR titles with JIRA tickets: `[KB2C-123] feature description`
 - 🚀 Create Pull Requests directly using GitHub CLI
 - ⚡ Simple `git open-pr` command for one-click operation
-- 🤖 AI-powered PR description updates with `git update-pr-desc` using Claude
-- 🔍 AI-powered PR code reviews with `git pr-review` using Claude
+- 🤖 AI-powered PR description updates with `git update-pr-desc` using Claude or Gemini
+- 🔍 AI-powered PR code reviews with `git pr-review` using Claude or Gemini
 
 ## Installation
 
@@ -22,7 +22,7 @@ Install globally via npm:
 pnpm add -g git-pr-ai
 ```
 
-The installation will automatically set up git aliases, so you can use `git pr-ai`, `git update-pr-desc`, and `git pr-review` directly!
+The installation will automatically set up git aliases, so you can use `git pr-ai init`, `git open-pr`, `git update-pr-desc`, and `git pr-review` directly!
 
 ## Prerequisites
 
@@ -33,9 +33,10 @@ Before using this tool, you need to install:
    - Install: https://cli.github.com/
    - Authenticate: `gh auth login`
 
-2. **Claude Code** - Required for AI-powered PR descriptions (optional)
-   - Install: https://docs.anthropic.com/en/docs/claude-code
-   - Authenticate with your Anthropic account
+2. **AI Provider** - Required for AI-powered feature (Choose only one)
+
+   - **Claude Code**
+   - **Gemini CLI**
 
 ## Usage
 
@@ -68,11 +69,13 @@ git update-pr-desc "Focus on performance improvements and add test coverage deta
 **Example Output:**
 
 ```
-🔍 Checking GitHub CLI...
 🔍 Checking for PR on current branch...
+🔗 PR URL: https://github.com/owner/repo/pull/123
+📋 Target branch: main
+🌿 Current branch: feature/KB2C-123-add-login-page
+🤖 Using CLAUDE for AI assistance
 📝 Additional context: Focus on performance improvements and add test coverage details
-✅ PR found! Updating description...
-# Claude will then interactively help you generate the description
+# AI will then interactively help you generate the description
 ✅ PR description updated successfully!
 ```
 
@@ -94,13 +97,23 @@ git pr-review https://github.com/owner/repo/pull/456
 
 ```
 🔍 Looking for PR on current branch...
-🔍 Reviewing PR #123...
+🔍 Reviewing PR #123 using CLAUDE...
 🔗 PR URL: https://github.com/owner/repo/pull/123
 📋 Target branch: main
 🌿 Source branch: feature/KB2C-123-add-login-page
-# Claude will analyze the PR and provide comprehensive review
+# AI will analyze the PR and provide comprehensive review
 ✅ PR review completed and comment posted!
 ```
+
+## Configuration (Optional)
+
+The default agent is Claude. You can run the setup command to create your configuration:
+
+```bash
+git pr-ai init
+```
+
+The command will create a `.git-pr-ai.json` file in your project root with your selection.
 
 ## Troubleshooting
 
@@ -128,9 +141,10 @@ git pr-review https://github.com/owner/repo/pull/456
    - Create a PR first using `git open-pr`
    - Or switch to a branch that has an existing PR
 
-6. **Claude Code not installed**
-   - Install Claude Code from https://docs.anthropic.com/en/docs/claude-code
-   - Ensure it's properly authenticated
+6. **AI Provider not installed**
+   - For Claude: Install Claude Code from https://docs.anthropic.com/en/docs/claude-code
+   - For Gemini: Install the Gemini CLI tool
+   - Ensure your chosen provider is properly authenticated
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "bin": {
     "git-open-pr": "./dist/git-open-pr.js",
     "git-update-pr-desc": "./dist/git-update-pr-desc.js",
-    "git-pr-review": "./dist/git-pr-review.js"
+    "git-pr-review": "./dist/git-pr-review.js",
+    "git-pr-ai": "./dist/git-pr-ai-init.js"
   },
   "files": [
     "dist",
@@ -49,6 +50,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@inquirer/prompts": "^7.8.0",
     "zx": "^8.7.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@inquirer/prompts':
+        specifier: ^7.8.0
+        version: 7.8.0(@types/node@24.1.0)
       zx:
         specifier: ^8.7.2
         version: 8.7.2
@@ -115,6 +118,127 @@ packages:
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+
+  '@inquirer/checkbox@4.2.0':
+    resolution: {integrity: sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.14':
+    resolution: {integrity: sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.15':
+    resolution: {integrity: sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.15':
+    resolution: {integrity: sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.17':
+    resolution: {integrity: sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.13':
+    resolution: {integrity: sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.2.1':
+    resolution: {integrity: sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.17':
+    resolution: {integrity: sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.17':
+    resolution: {integrity: sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.8.0':
+    resolution: {integrity: sha512-JHwGbQ6wjf1dxxnalDYpZwZxUEosT+6CPGD9Zh4sm9WXdtUp9XODCQD3NjSTmu+0OAyxWXNOqf0spjIymJa2Tw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.5':
+    resolution: {integrity: sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.1.0':
+    resolution: {integrity: sha512-PMk1+O/WBcYJDq2H7foV0aAZSmDdkzZB9Mw2v/DmONRJopwA/128cS9M/TXWLKKdEQKZnKwBzqu2G4x/2Nqx8Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.3.1':
+    resolution: {integrity: sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.8':
+    resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
@@ -247,8 +371,16 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
   ansis@4.1.0:
@@ -292,6 +424,17 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -328,6 +471,9 @@ packages:
     peerDependenciesMeta:
       oxc-resolver:
         optional: true
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -413,6 +559,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -469,6 +619,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
@@ -613,6 +767,10 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -669,6 +827,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
@@ -688,6 +850,14 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
   zx@8.7.2:
     resolution: {integrity: sha512-4Wtl46msLFx6QW6GjLu1aRnFhavukT4VSp4tdXvfRIBRNW3RP7Si3RlRFD7YeQeecQBacVFRQQgm5LTvE/YEGQ==}
@@ -877,6 +1047,122 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@inquirer/checkbox@4.2.0(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/confirm@5.1.14(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/core@10.1.15(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/editor@4.2.15(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      external-editor: 3.1.0
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/expand@4.0.17(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/figures@1.0.13': {}
+
+  '@inquirer/input@4.2.1(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/number@3.0.17(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/password@4.0.17(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      ansi-escapes: 4.3.2
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/prompts@7.8.0(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/checkbox': 4.2.0(@types/node@24.1.0)
+      '@inquirer/confirm': 5.1.14(@types/node@24.1.0)
+      '@inquirer/editor': 4.2.15(@types/node@24.1.0)
+      '@inquirer/expand': 4.0.17(@types/node@24.1.0)
+      '@inquirer/input': 4.2.1(@types/node@24.1.0)
+      '@inquirer/number': 3.0.17(@types/node@24.1.0)
+      '@inquirer/password': 4.0.17(@types/node@24.1.0)
+      '@inquirer/rawlist': 4.1.5(@types/node@24.1.0)
+      '@inquirer/search': 3.1.0(@types/node@24.1.0)
+      '@inquirer/select': 4.3.1(@types/node@24.1.0)
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/rawlist@4.1.5(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/search@3.1.0(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/select@4.3.1(@types/node@24.1.0)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.1.0)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@24.1.0)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@inquirer/type@3.0.8(@types/node@24.1.0)':
+    optionalDependencies:
+      '@types/node': 24.1.0
+
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
@@ -993,7 +1279,15 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansis@4.1.0: {}
 
@@ -1028,6 +1322,14 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  cli-width@4.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1049,6 +1351,8 @@ snapshots:
       path-type: 4.0.0
 
   dts-resolver@2.1.1: {}
+
+  emoji-regex@8.0.0: {}
 
   empathic@2.0.0: {}
 
@@ -1135,6 +1439,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -1178,6 +1484,8 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  mute-stream@2.0.0: {}
 
   os-tmpdir@1.0.2: {}
 
@@ -1304,6 +1612,12 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -1356,6 +1670,8 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  type-fest@0.21.3: {}
+
   typescript@5.9.2: {}
 
   unconfig@7.3.2:
@@ -1372,5 +1688,13 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  yoctocolors-cjs@2.1.2: {}
 
   zx@8.7.2: {}

--- a/src/cli/pr-ai-init.ts
+++ b/src/cli/pr-ai-init.ts
@@ -1,0 +1,69 @@
+import { writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { select } from "@inquirer/prompts";
+import { GitPrAiConfig } from "../config.js";
+
+const CONFIG_FILENAME = ".git-pr-ai.json";
+
+async function promptAgentSelection(): Promise<"claude" | "gemini"> {
+  const answer = await select({
+    message: "🤖 Which AI agent would you like to use?",
+    choices: [
+      {
+        name: "Claude (Anthropic)",
+        value: "claude" as const,
+      },
+      {
+        name: "Gemini (Google)",
+        value: "gemini" as const,
+      },
+    ],
+  });
+
+  return answer;
+}
+
+async function initConfig(force: boolean = false) {
+  const configPath = join(process.cwd(), CONFIG_FILENAME);
+
+  if (existsSync(configPath) && !force) {
+    console.log(`⚠️ ${CONFIG_FILENAME} already exists in current directory.`);
+    console.log("Use --force to overwrite the existing configuration.");
+    return;
+  }
+
+  const selectedAgent = await promptAgentSelection();
+
+  const config: GitPrAiConfig = {
+    agent: selectedAgent,
+  };
+
+  try {
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log(`\n✅ ${CONFIG_FILENAME} created successfully!`);
+    console.log(`🎯 Selected AI agent: ${selectedAgent}`);
+    console.log("\nConfiguration options:");
+    console.log(
+      '- agent: "claude" | "gemini" - Choose AI agent for PR operations'
+    );
+    console.log("\nEnvironment variables:");
+    console.log(
+      "- GIT_PR_AI_AGENT: Override agent setting via environment variable"
+    );
+  } catch (error) {
+    console.error(`❌ Failed to create ${CONFIG_FILENAME}:`, error);
+    process.exit(1);
+  }
+}
+
+async function main() {
+  try {
+    await initConfig();
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error("❌ Error:", errorMessage);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/cli/pr-review.ts
+++ b/src/cli/pr-review.ts
@@ -1,5 +1,6 @@
 import { $ } from "zx";
 import { checkGitHubCLI } from "../utils.js";
+import { executeAICommand, loadConfig } from "../config.js";
 
 interface PRInfo {
   url: string;
@@ -59,7 +60,8 @@ async function getCurrentBranchPRInfo(): Promise<PRInfo | null> {
 }
 
 async function reviewPR(prInfo: PRInfo): Promise<void> {
-  console.log(`🔍 Reviewing PR #${prInfo.number}...`);
+  const config = await loadConfig();
+  console.log(`🔍 Reviewing PR #${prInfo.number} using ${config.agent.toUpperCase()}...`);
   console.log(`🔗 PR URL: ${prInfo.url}`);
   console.log(`📋 Target branch: ${prInfo.targetBranch}`);
   console.log(`🌿 Source branch: ${prInfo.currentBranch}`);
@@ -91,7 +93,7 @@ Please follow these steps:
 Focus on being constructive and helpful in the review.`;
 
   try {
-    await $({ stdio: "inherit" })`claude ${prompt}`;
+    await executeAICommand(prompt);
     console.log("✅ PR review completed and comment posted!");
   } catch (error) {
     console.error("❌ Failed to complete PR review");
@@ -118,12 +120,17 @@ Examples:
     # Review specific PR by URL
 
 Description:
-  This tool uses Claude AI to perform comprehensive code reviews on GitHub Pull Requests.
+  This tool uses AI (Claude or Gemini) to perform comprehensive code reviews on GitHub Pull Requests.
   It analyzes code changes, identifies potential issues, and posts constructive feedback.
+
+Configuration:
+  - Create .git-pr-ai.json with {"agent": "claude"} or {"agent": "gemini"}
+  - Or set GIT_PR_AI_AGENT environment variable to "claude" or "gemini"
+  - Defaults to Claude if no configuration is provided
 
 Prerequisites:
   - GitHub CLI (gh) must be installed and authenticated
-  - Claude Code must be installed and authenticated
+  - Claude Code (for Claude) or Gemini CLI (for Gemini) must be installed and authenticated
   `);
 }
 

--- a/src/cli/update-pr-desc.ts
+++ b/src/cli/update-pr-desc.ts
@@ -1,5 +1,6 @@
 import { $ } from "zx";
 import { checkGitHubCLI } from "../utils.js";
+import { executeAICommand, loadConfig } from "../config.js";
 
 async function getPRInfo(): Promise<{
   targetBranch: string;
@@ -38,9 +39,11 @@ async function main() {
     process.exit(1);
   }
 
+  const config = await loadConfig();
   console.log(`🔗 PR URL: ${prInfo.url}`);
   console.log(`📋 Target branch: ${prInfo.targetBranch}`);
   console.log(`🌿 Current branch: ${prInfo.currentBranch}`);
+  console.log(`🤖 Using ${config.agent.toUpperCase()} for AI assistance`);
 
   let prompt = `Write a PR description following these steps:
 1. Look for pull_request_template.md in .github directory (use Glob pattern: ".github/**" to find it)
@@ -62,7 +65,7 @@ Please incorporate this additional context into the PR description where relevan
   }
 
   try {
-    await $({ stdio: "inherit" })`claude ${prompt}`;
+    await executeAICommand(prompt);
     console.log("✅ PR description updated successfully!");
   } catch (error) {
     console.error("❌ Failed to update PR description");

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,70 @@
+import { $ } from 'zx';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface GitPrAiConfig {
+  agent: 'claude' | 'gemini';
+}
+
+const DEFAULT_CONFIG: GitPrAiConfig = {
+  agent: 'claude'
+};
+
+export async function loadConfig(): Promise<GitPrAiConfig> {
+  const configPath = join(process.cwd(), '.git-pr-ai.json');
+  let config = { ...DEFAULT_CONFIG };
+
+  if (existsSync(configPath)) {
+    try {
+      const configContent = readFileSync(configPath, 'utf8');
+      const fileConfig = JSON.parse(configContent);
+      config = { ...config, ...fileConfig };
+    } catch (error) {
+      console.warn('⚠️ Failed to parse .git-pr-ai.json, using default configuration');
+    }
+  }
+
+  const envAgent = process.env.GIT_PR_AI_AGENT;
+  if (envAgent === 'claude' || envAgent === 'gemini') {
+    config.agent = envAgent;
+  }
+
+  return config;
+}
+
+export async function executeAICommand(prompt: string): Promise<void> {
+  const config = await loadConfig();
+  
+  switch (config.agent) {
+    case 'claude':
+      await checkClaudeCLI();
+      await $({ stdio: "inherit" })`claude ${prompt}`;
+      break;
+    case 'gemini':
+      await checkGeminiCLI();
+      await $({ stdio: "inherit" })`gemini -i ${prompt}`;
+      break;
+    default:
+      throw new Error(`Unsupported AI agent: ${config.agent}`);
+  }
+}
+
+async function checkClaudeCLI(): Promise<void> {
+  try {
+    await $`claude --version`.quiet();
+  } catch (error) {
+    console.error("❌ Claude CLI not found");
+    console.error("Please install Claude Code: https://claude.ai/code");
+    process.exit(1);
+  }
+}
+
+async function checkGeminiCLI(): Promise<void> {
+  try {
+    await $`gemini --version`.quiet();
+  } catch (error) {
+    console.error("❌ Gemini CLI not found");
+    console.error("Please install Gemini CLI");
+    process.exit(1);
+  }
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     "git-open-pr": "src/cli/open-pr.ts",
     "git-update-pr-desc": "src/cli/update-pr-desc.ts",
     "git-pr-review": "src/cli/pr-review.ts",
+    "git-pr-ai-init": "src/cli/pr-ai-init.ts",
     "postinstall": "scripts/postinstall.ts"
   },
   banner: {


### PR DESCRIPTION
## Summary

feat: add support for Gemini AI as alternative to Claude

This PR introduces support for Google's Gemini AI alongside the existing Claude support, giving users flexibility in choosing their preferred AI provider for PR operations.

### Key Changes

- **🎯 AI Provider Configuration**: Added `git pr-ai init` command to set up AI agent preferences  
- **🤖 Multi-AI Support**: Both Claude and Gemini can now be used for PR descriptions and reviews
- **⚙️ Configuration System**: New `.git-pr-ai.json` config file with environment variable override support
- **📚 Updated Documentation**: README reflects new AI provider options and setup instructions

### Technical Details

- Added `@inquirer/prompts` dependency for interactive configuration
- Created `src/config.ts` for centralized AI agent management
- Updated `src/cli/pr-review.ts` and `src/cli/update-pr-desc.ts` to use configurable AI
- New binary `git-pr-ai-init` for easy setup

### Configuration Options

Users can now:
1. Run `git pr-ai init` to choose their preferred AI provider
2. Set `GIT_PR_AI_AGENT=claude|gemini` environment variable
3. Default to Claude if no configuration is provided

### Related issues

- https://github.com/leochiu-a/git-pr-ai/issues/13