### PR TITLE
fix: jira pattern support alphanumeric keys

### DIFF
--- a/.changeset/hot-walls-act.md
+++ b/.changeset/hot-walls-act.md
@@ -1,0 +1,5 @@
+---
+'git-pr-ai': patch
+---
+
+fix: jira pattern support alphanumeric keys

--- a/packages/cli/src/jira.ts
+++ b/packages/cli/src/jira.ts
@@ -2,7 +2,7 @@ import { loadConfig } from './config'
 import { JiraTicketDetails } from './cli/plan-issue/types'
 
 export function extractJiraTicket(branchName: string): string | null {
-  const jiraPattern = /([A-Z]+-\d+)/
+  const jiraPattern = /([A-Z0-9]+-\d+)/
   const match = branchName.match(jiraPattern)
 
   if (!match) {


### PR DESCRIPTION
## Summary

This PR fixes the JIRA ticket extraction functionality to support JIRA project keys that contain numbers, not just letters. Previously, the regex pattern only matched project keys with letters (A-Z), but JIRA allows alphanumeric project keys.

## Changes

- **Type**: Bug fix 🐛
- **File Modified**: `packages/cli/src/jira.ts`
- **Change**: Updated regex pattern from `([A-Z]+-\d+)` to `([A-Z0-9]+-\d+)` to include digits in project keys

## Before vs After

**Before**: Only matched project keys like `ABC-123`, `TEST-456`
**After**: Now also matches project keys like `ABC1-123`, `TEST2-456`, `A1B2-789`

## Testing

To test this fix:
1. Create a branch with a JIRA ticket that has numbers in the project key (e.g. `feature/ABC123-456-new-feature`)
2. Run the CLI tool to extract the JIRA ticket
3. Verify that `ABC123-456` is correctly extracted and processed

## Breaking Changes

None. This change is backward compatible and only expands the supported JIRA ticket formats.

## Related Issues

This fix ensures compatibility with organizations that use numeric characters in their JIRA project keys, which is a valid JIRA configuration.