### PR TITLE
feat: add pr stats command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,8 @@
     "git-pr-ai": "./dist/git-pr-ai.js",
     "git-create-branch": "./dist/git-create-branch.js",
     "git-plan-issue": "./dist/git-plan-issue.js",
-    "git-take-issue": "./dist/git-take-issue.js"
+    "git-take-issue": "./dist/git-take-issue.js",
+    "git-pr-stats": "./dist/git-pr-stats.js"
   },
   "files": [
     "dist",

--- a/packages/cli/src/cli/pr-stats.ts
+++ b/packages/cli/src/cli/pr-stats.ts
@@ -1,0 +1,195 @@
+import { Command } from 'commander'
+import { checkGitCLI } from '../git-helpers'
+import { getCurrentProvider } from '../providers/factory'
+
+interface PeriodStats {
+  totalPRs: number
+  authorStats: Record<string, number>
+  statusStats: {
+    open: number
+    closed: number
+    merged: number
+  }
+}
+
+type PeriodType = 'weekly' | 'monthly'
+
+function getWeekRange(weeksAgo: number): { start: string; end: string } {
+  const now = new Date()
+  const currentDay = now.getDay()
+  const daysToMonday = currentDay === 0 ? 6 : currentDay - 1
+
+  const weekStart = new Date(now)
+  weekStart.setDate(now.getDate() - daysToMonday - (weeksAgo * 7))
+  weekStart.setHours(0, 0, 0, 0)
+
+  const weekEnd = new Date(weekStart)
+  weekEnd.setDate(weekStart.getDate() + 6)
+  weekEnd.setHours(23, 59, 59, 999)
+
+  return {
+    start: weekStart.toISOString().split('T')[0],
+    end: weekEnd.toISOString().split('T')[0]
+  }
+}
+
+function getCurrentMonthRange(): { start: string; end: string } {
+  const now = new Date()
+  
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
+  monthStart.setHours(0, 0, 0, 0)
+  
+  const monthEnd = new Date(now)
+  monthEnd.setHours(23, 59, 59, 999)
+
+  return {
+    start: monthStart.toISOString().split('T')[0],
+    end: monthEnd.toISOString().split('T')[0]
+  }
+}
+
+function formatPeriodRange(start: string, end: string, type: PeriodType): string {
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+  
+  if (type === 'monthly') {
+    return startDate.toLocaleDateString('en-US', { 
+      month: 'long', 
+      year: 'numeric'
+    })
+  }
+  
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString('en-US', { 
+      month: 'short', 
+      day: 'numeric',
+      year: startDate.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined
+    })
+  }
+  
+  return `${formatDate(startDate)} - ${formatDate(endDate)}`
+}
+
+async function getPRStats(type: PeriodType): Promise<PeriodStats> {
+  const provider = await getCurrentProvider()
+  
+  const { start, end } = type === 'weekly' ? getWeekRange(1) : getCurrentMonthRange()
+  const prs = await provider.searchPRsByDateRange(start, end)
+  
+  const authorStats: Record<string, number> = {}
+  const statusStats = { open: 0, closed: 0, merged: 0 }
+
+  prs.forEach(pr => {
+    authorStats[pr.author] = (authorStats[pr.author] || 0) + 1
+    
+    if (pr.state === 'merged') {
+      statusStats.merged++
+    } else if (pr.state === 'closed') {
+      statusStats.closed++
+    } else {
+      statusStats.open++
+    }
+  })
+
+  return {
+    totalPRs: prs.length,
+    authorStats,
+    statusStats
+  }
+}
+
+function displayStats(stats: PeriodStats, type: PeriodType) {
+  const periodEmoji = type === 'weekly' ? '📅' : '🗓️'
+  const { start, end } = type === 'weekly' ? getWeekRange(1) : getCurrentMonthRange()
+  const periodRange = formatPeriodRange(start, end, type)
+  
+  console.log(`\n📊 ${type === 'weekly' ? 'Weekly' : 'Monthly'} PR Statistics\n`)
+  
+  console.log(`${periodEmoji} ${type === 'weekly' ? 'Last Week' : 'This Month'}: ${periodRange}`)
+  console.log(`   Total PRs: ${stats.totalPRs}`)
+  
+  if (stats.totalPRs > 0) {
+    console.log(`   Status: Open: ${stats.statusStats.open}, Closed: ${stats.statusStats.closed}, Merged: ${stats.statusStats.merged}`)
+    
+    if (Object.keys(stats.authorStats).length > 0) {
+      console.log(`   Authors:`)
+      Object.entries(stats.authorStats)
+        .sort(([,a], [,b]) => b - a)
+        .forEach(([author, count]) => {
+          console.log(`     ${author}: ${count}`)
+        })
+    }
+  }
+  console.log()
+}
+
+function setupCommander() {
+  const program = new Command()
+
+  program
+    .name('git-pr-stats')
+    .description('Get PR statistics for the current repository')
+    .option('--weekly', 'Show weekly statistics (last week)')
+    .option('--monthly', 'Show monthly statistics (this month)')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ git pr-stats --weekly
+    Show PR statistics for last week
+
+  $ git pr-stats --monthly
+    Show PR statistics for this month
+
+Features:
+  - Shows total PR count per period
+  - Breaks down by author and status (open/closed/merged)
+  - Weekly periods: Monday to Sunday
+  - Monthly periods: Full calendar months
+
+Prerequisites:
+  - Git provider CLI (gh for GitHub, glab for GitLab) must be installed and authenticated
+    `,
+    )
+
+  return program
+}
+
+async function main() {
+  const program = setupCommander()
+
+  program.action(async (options: { weekly?: boolean; monthly?: boolean }) => {
+    try {
+      await checkGitCLI()
+      
+      // Check if both options are provided
+      if (options.weekly && options.monthly) {
+        console.error('❌ Please specify either --weekly or --monthly, not both')
+        process.exit(1)
+      }
+      
+      // Default to weekly if no option is specified
+      if (!options.weekly && !options.monthly) {
+        options.weekly = true
+      }
+      
+      const type: PeriodType = options.weekly ? 'weekly' : 'monthly'
+      const periodLabel = type === 'weekly' ? 'last week' : 'this month'
+      
+      console.log(`🔍 Analyzing PR activity for ${periodLabel}...`)
+      
+      const stats = await getPRStats(type)
+      displayStats(stats, type)
+      
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
+      console.error('Error:', errorMessage)
+      process.exit(1)
+    }
+  })
+
+  program.parse()
+}
+
+main()

--- a/packages/cli/src/providers/github.ts
+++ b/packages/cli/src/providers/github.ts
@@ -349,4 +349,22 @@ export class GitHubProvider implements GitProvider {
       )
     }
   }
+
+  async searchPRsByDateRange(startDate: string, endDate: string): Promise<PR[]> {
+    try {
+      const result = await $`gh search prs --repo :owner/:repo --created ${startDate}..${endDate} --json number,title,url,state,author --limit 1000`
+      const prs = JSON.parse(result.stdout)
+
+      return prs.map((pr: any) => ({
+        number: pr.number.toString(),
+        title: pr.title,
+        url: pr.url,
+        state: pr.state.toLowerCase(),
+        author: pr.author.login,
+      }))
+    } catch (error) {
+      console.warn(`⚠️ Could not search PRs for date range ${startDate}..${endDate}`)
+      return []
+    }
+  }
 }

--- a/packages/cli/src/providers/gitlab.ts
+++ b/packages/cli/src/providers/gitlab.ts
@@ -334,4 +334,23 @@ export class GitLabProvider implements GitProvider {
       )
     }
   }
+
+  async searchPRsByDateRange(startDate: string, endDate: string): Promise<PR[]> {
+    try {
+      // GitLab CLI search might be different, using basic approach
+      const result = await $`glab mr list --created-after=${startDate} --created-before=${endDate} --all --per-page=100 --json`
+      const mrs = JSON.parse(result.stdout)
+
+      return mrs.map((mr: any) => ({
+        number: mr.iid.toString(),
+        title: mr.title,
+        url: mr.web_url,
+        state: mr.state.toLowerCase(),
+        author: mr.author.username,
+      }))
+    } catch (error) {
+      console.warn(`⚠️ Could not search MRs for date range ${startDate}..${endDate}`)
+      return []
+    }
+  }
 }

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -56,6 +56,9 @@ export interface GitProvider {
 
   /** Create a new issue */
   createIssue(title: string, body: string, labels?: string[]): Promise<void>
+
+  /** Search for PRs/MRs within a specific date range */
+  searchPRsByDateRange(startDate: string, endDate: string): Promise<PR[]>
 }
 
 export interface IssueDetails {

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'git-create-branch': 'src/cli/create-branch/create-branch.ts',
     'git-plan-issue': 'src/cli/plan-issue/plan-issue.ts',
     'git-take-issue': 'src/cli/take-issue/take-issue.ts',
+    'git-pr-stats': 'src/cli/pr-stats.ts',
     postinstall: 'scripts/postinstall.ts',
   },
   format: ['esm'],


### PR DESCRIPTION
- Introduced a new command  to display PR statistics for the current repository.
- Added functionality to show weekly and monthly PR counts, broken down by author and status (open/closed/merged).
- Implemented date range searching for PRs in both GitHub and GitLab providers.
- Updated package.json and tsdown.config.ts to include the new command.