### PR TITLE
fix: gitlab command quotes

### DIFF
--- a/.changeset/upset-pumas-occur.md
+++ b/.changeset/upset-pumas-occur.md
@@ -1,0 +1,5 @@
+---
+'git-pr-ai': patch
+---
+
+fix: gitlab command quotes

--- a/packages/cli/src/providers/gitlab.ts
+++ b/packages/cli/src/providers/gitlab.ts
@@ -68,7 +68,7 @@ export class GitLabProvider implements GitProvider {
     baseBranch: string,
   ): Promise<void> {
     const spinner = ora('Creating Merge Request...').start()
-    await $`glab mr create --title "${title}" --target-branch ${baseBranch} --source-branch ${branch} --web`
+    await $`glab mr create --title ${title} --target-branch ${baseBranch} --source-branch ${branch} --description "" --web`
     spinner.succeed('Merge Request created successfully!')
   }
 
@@ -100,7 +100,7 @@ export class GitLabProvider implements GitProvider {
       }
 
       if (options.comment) {
-        await $`glab mr note ${prNumber} --message "${options.comment}"`
+        await $`glab mr note ${prNumber} --message ${options.comment}`
       }
 
       if (


### PR DESCRIPTION
## Description

This PR fixes quote handling in GitLab merge request commands. The changes remove unnecessary double quotes around variables in shell command executions, which could cause issues when the variables contain special characters or are already properly escaped.

### Changes Made

- Removed unnecessary double quotes around `title` parameter in `glab mr create` command
- Removed unnecessary double quotes around `options.comment` parameter in `glab mr note` command  
- Added explicit `--description ""` parameter to ensure empty description is properly handled

### Why This Fix Is Needed

The previous implementation wrapped variables in double quotes, but the underlying shell command execution (using `$` template literals) already handles proper escaping. The extra quotes could cause issues when:
- The title or comment contains special characters
- The variables are already properly escaped
- GitLab CLI expects unquoted parameters in certain contexts

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

To test this fix:

1. Create a GitLab merge request with a title containing special characters (e.g., quotes, apostrophes)
2. Add a comment to an existing merge request with special characters
3. Verify that both operations complete successfully without shell escaping errors

## Breaking Changes

None. This is a backward-compatible bug fix that improves the reliability of GitLab command execution.