### PR TITLE
feat: add weekly summary command

### DIFF
--- a/.changeset/kind-rooms-nail.md
+++ b/.changeset/kind-rooms-nail.md
@@ -1,0 +1,5 @@
+---
+'git-pr-ai': minor
+---
+
+feat: add git weekly-summary cli

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,367 @@
+{
+  "name": "git-pr-ai",
+  "version": "1.8.5",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "git-pr-ai",
+      "version": "1.8.5",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^7.8.0",
+        "commander": "^14.0.0",
+        "dayjs": "^1.11.13",
+        "ora": "^8.2.0",
+        "zx": "^8.7.2"
+      },
+      "bin": {
+        "git-create-branch": "dist/git-create-branch.js",
+        "git-open-pr": "dist/git-open-pr.js",
+        "git-plan-issue": "dist/git-plan-issue.js",
+        "git-pr-ai": "dist/git-pr-ai.js",
+        "git-pr-review": "dist/git-pr-review.js",
+        "git-take-issue": "dist/git-take-issue.js",
+        "git-update-pr-desc": "dist/git-update-pr-desc.js",
+        "git-weekly-summary": "dist/git-weekly-summary.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.1.0",
+        "oxlint": "^1.9.0",
+        "prettier": "^3.6.2",
+        "tsdown": "^0.13.2",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/@inquirer+prompts@7.8.0_@types+node@24.1.0/node_modules/@inquirer/prompts": {
+      "version": "7.8.0",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.2.0",
+        "@inquirer/confirm": "^5.1.14",
+        "@inquirer/editor": "^4.2.15",
+        "@inquirer/expand": "^4.0.17",
+        "@inquirer/input": "^4.2.1",
+        "@inquirer/number": "^3.0.17",
+        "@inquirer/password": "^4.0.17",
+        "@inquirer/rawlist": "^4.1.5",
+        "@inquirer/search": "^3.1.0",
+        "@inquirer/select": "^4.3.1"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.18.2",
+        "@inquirer/type": "^3.0.8",
+        "tshy": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/@types+node@24.1.0/node_modules/@types/node": {
+      "version": "24.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "../../node_modules/.pnpm/commander@14.0.0/node_modules/commander": {
+      "version": "14.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@eslint/js": "^9.4.0",
+        "@types/jest": "^29.2.4",
+        "@types/node": "^22.7.4",
+        "eslint": "^9.17.0",
+        "eslint-config-prettier": "^10.0.1",
+        "eslint-plugin-jest": "^28.3.0",
+        "globals": "^16.0.0",
+        "jest": "^29.3.1",
+        "prettier": "^3.2.5",
+        "ts-jest": "^29.0.3",
+        "tsd": "^0.31.0",
+        "typescript": "^5.0.4",
+        "typescript-eslint": "^8.12.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../../node_modules/.pnpm/ora@8.2.0/node_modules/ora": {
+      "version": "8.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.5.0",
+        "ava": "^5.3.1",
+        "get-stream": "^9.0.1",
+        "transform-tty": "^1.0.11",
+        "tsd": "^0.31.1",
+        "xo": "^0.59.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/.pnpm/oxlint@1.9.0/node_modules/oxlint": {
+      "version": "1.9.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxc_language_server": "bin/oxc_language_server",
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": ">=8.*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/darwin-arm64": "1.9.0",
+        "@oxlint/darwin-x64": "1.9.0",
+        "@oxlint/linux-arm64-gnu": "1.9.0",
+        "@oxlint/linux-arm64-musl": "1.9.0",
+        "@oxlint/linux-x64-gnu": "1.9.0",
+        "@oxlint/linux-x64-musl": "1.9.0",
+        "@oxlint/win32-arm64": "1.9.0",
+        "@oxlint/win32-x64": "1.9.0"
+      }
+    },
+    "../../node_modules/.pnpm/prettier@3.6.2/node_modules/prettier": {
+      "version": "3.6.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "../../node_modules/.pnpm/tsdown@0.13.2_typescript@5.9.2/node_modules/tsdown": {
+      "version": "0.13.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansis": "^4.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "debug": "^4.4.1",
+        "diff": "^8.0.2",
+        "empathic": "^2.0.0",
+        "hookable": "^5.5.3",
+        "rolldown": "^1.0.0-beta.30",
+        "rolldown-plugin-dts": "^0.15.0",
+        "semver": "^7.7.2",
+        "tinyexec": "^1.0.1",
+        "tinyglobby": "^0.2.14",
+        "tree-kill": "^1.2.2",
+        "unconfig": "^7.3.2"
+      },
+      "bin": {
+        "tsdown": "dist/run.mjs"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/core": "^0.18.2",
+        "@sxzz/eslint-config": "^7.1.2",
+        "@sxzz/prettier-config": "^2.2.3",
+        "@sxzz/test-utils": "^0.5.9",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^24.1.0",
+        "@types/semver": "^7.7.0",
+        "@unocss/eslint-plugin": "^66.4.0",
+        "@vueuse/core": "^13.6.0",
+        "bumpp": "^10.2.2",
+        "eslint": "^9.32.0",
+        "lightningcss": "^1.30.1",
+        "oxc-minify": "^0.79.1",
+        "pkg-types": "^2.2.0",
+        "prettier": "^3.6.2",
+        "publint": "^0.3.12",
+        "tsx": "^4.20.3",
+        "typedoc": "^0.28.9",
+        "typedoc-plugin-markdown": "^4.8.0",
+        "typedoc-vitepress-theme": "^1.1.2",
+        "typescript": "~5.9.2",
+        "unocss": "^66.4.0",
+        "unplugin-lightningcss": "^0.4.1",
+        "unplugin-unused": "^0.5.1",
+        "vite": "npm:rolldown-vite@latest",
+        "vitepress": "^2.0.0-alpha.7",
+        "vitepress-plugin-group-icons": "^1.6.1",
+        "vitepress-plugin-llms": "^1.7.2",
+        "vitest": "^3.2.4",
+        "vue": "^3.5.18"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@arethetypeswrong/core": "^0.18.1",
+        "publint": "^0.3.0",
+        "typescript": "^5.0.0",
+        "unplugin-lightningcss": "^0.4.0",
+        "unplugin-unused": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@arethetypeswrong/core": {
+          "optional": true
+        },
+        "publint": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "unplugin-lightningcss": {
+          "optional": true
+        },
+        "unplugin-unused": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/typescript@5.9.2/node_modules/typescript": {
+      "version": "5.9.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "devDependencies": {
+        "@dprint/formatter": "^0.4.1",
+        "@dprint/typescript": "0.93.4",
+        "@esfx/canceltoken": "^1.0.0",
+        "@eslint/js": "^9.20.0",
+        "@octokit/rest": "^21.1.1",
+        "@types/chai": "^4.3.20",
+        "@types/diff": "^7.0.1",
+        "@types/minimist": "^1.2.5",
+        "@types/mocha": "^10.0.10",
+        "@types/ms": "^0.7.34",
+        "@types/node": "latest",
+        "@types/source-map-support": "^0.5.10",
+        "@types/which": "^3.0.4",
+        "@typescript-eslint/rule-tester": "^8.24.1",
+        "@typescript-eslint/type-utils": "^8.24.1",
+        "@typescript-eslint/utils": "^8.24.1",
+        "azure-devops-node-api": "^14.1.0",
+        "c8": "^10.1.3",
+        "chai": "^4.5.0",
+        "chokidar": "^4.0.3",
+        "diff": "^7.0.0",
+        "dprint": "^0.49.0",
+        "esbuild": "^0.25.0",
+        "eslint": "^9.20.1",
+        "eslint-formatter-autolinkable-stylish": "^1.4.0",
+        "eslint-plugin-regexp": "^2.7.0",
+        "fast-xml-parser": "^4.5.2",
+        "glob": "^10.4.5",
+        "globals": "^15.15.0",
+        "hereby": "^1.10.0",
+        "jsonc-parser": "^3.3.1",
+        "knip": "^5.44.4",
+        "minimist": "^1.2.8",
+        "mocha": "^10.8.2",
+        "mocha-fivemat-progress-reporter": "^0.1.0",
+        "monocart-coverage-reports": "^2.12.1",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "playwright": "^1.50.1",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.24.1",
+        "which": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "../../node_modules/.pnpm/zx@8.7.2/node_modules/zx": {
+      "version": "8.7.2",
+      "license": "Apache-2.0",
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 12.17.0"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "resolved": "../../node_modules/.pnpm/@inquirer+prompts@7.8.0_@types+node@24.1.0/node_modules/@inquirer/prompts",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "resolved": "../../node_modules/.pnpm/@types+node@24.1.0/node_modules/@types/node",
+      "link": true
+    },
+    "node_modules/commander": {
+      "resolved": "../../node_modules/.pnpm/commander@14.0.0/node_modules/commander",
+      "link": true
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
+    "node_modules/ora": {
+      "resolved": "../../node_modules/.pnpm/ora@8.2.0/node_modules/ora",
+      "link": true
+    },
+    "node_modules/oxlint": {
+      "resolved": "../../node_modules/.pnpm/oxlint@1.9.0/node_modules/oxlint",
+      "link": true
+    },
+    "node_modules/prettier": {
+      "resolved": "../../node_modules/.pnpm/prettier@3.6.2/node_modules/prettier",
+      "link": true
+    },
+    "node_modules/tsdown": {
+      "resolved": "../../node_modules/.pnpm/tsdown@0.13.2_typescript@5.9.2/node_modules/tsdown",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "resolved": "../../node_modules/.pnpm/typescript@5.9.2/node_modules/typescript",
+      "link": true
+    },
+    "node_modules/zx": {
+      "resolved": "../../node_modules/.pnpm/zx@8.7.2/node_modules/zx",
+      "link": true
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,8 @@
     "git-pr-ai": "./dist/git-pr-ai.js",
     "git-create-branch": "./dist/git-create-branch.js",
     "git-plan-issue": "./dist/git-plan-issue.js",
-    "git-take-issue": "./dist/git-take-issue.js"
+    "git-take-issue": "./dist/git-take-issue.js",
+    "git-weekly-summary": "./dist/git-weekly-summary.js"
   },
   "files": [
     "dist",
@@ -51,6 +52,7 @@
   "dependencies": {
     "@inquirer/prompts": "^7.8.0",
     "commander": "^14.0.0",
+    "dayjs": "^1.11.13",
     "ora": "^8.2.0",
     "zx": "^8.7.2"
   },

--- a/packages/cli/src/cli/weekly-summary/commit-summary.ts
+++ b/packages/cli/src/cli/weekly-summary/commit-summary.ts
@@ -1,0 +1,97 @@
+import { $ } from 'zx'
+import { toGitLogFormat } from './date-utils'
+
+export interface CommitInfo {
+  hash: string
+  message: string
+  author: string
+  date: string
+}
+
+/**
+ * Get commits within the specified date range
+ */
+export async function getCommitsInRange(
+  since: string,
+  until: string,
+): Promise<CommitInfo[]> {
+  try {
+    const sinceTime = toGitLogFormat(since)
+    const untilTime = toGitLogFormat(until) + 'T23:59:59'
+
+    const result =
+      await $`git log --since=${sinceTime} --until=${untilTime} --pretty=format:"%H|%s|%an|%ai" --no-merges`
+
+    if (!result.stdout.trim()) {
+      return []
+    }
+
+    const commits = result.stdout
+      .trim()
+      .split('\n')
+      .map((line) => {
+        const [hash, message, author, date] = line.split('|')
+        return {
+          hash: hash.substring(0, 7), // Short hash
+          message: message.trim(),
+          author: author.trim(),
+          date: date.trim(),
+        }
+      })
+
+    return commits
+  } catch (error) {
+    console.error('Error fetching commits:', error)
+    return []
+  }
+}
+
+/**
+ * Group commits by type (feat, fix, docs, etc.)
+ */
+export function groupCommitsByType(
+  commits: CommitInfo[],
+): Record<string, CommitInfo[]> {
+  const groups: Record<string, CommitInfo[]> = {}
+
+  commits.forEach((commit) => {
+    const typeMatch = commit.message.match(/^(\w+)(?:\(.+\))?:\s*(.+)/)
+    const type = typeMatch ? typeMatch[1] : 'other'
+
+    if (!groups[type]) {
+      groups[type] = []
+    }
+
+    groups[type].push(commit)
+  })
+
+  return groups
+}
+
+/**
+ * Get commit statistics
+ */
+export function getCommitStats(commits: CommitInfo[]): {
+  total: number
+  byAuthor: Record<string, number>
+  byType: Record<string, number>
+} {
+  const byAuthor: Record<string, number> = {}
+  const byType: Record<string, number> = {}
+
+  commits.forEach((commit) => {
+    // Count by author
+    byAuthor[commit.author] = (byAuthor[commit.author] || 0) + 1
+
+    // Count by type
+    const typeMatch = commit.message.match(/^(\w+)(?:\(.+\))?:/)
+    const type = typeMatch ? typeMatch[1] : 'other'
+    byType[type] = (byType[type] || 0) + 1
+  })
+
+  return {
+    total: commits.length,
+    byAuthor,
+    byType,
+  }
+}

--- a/packages/cli/src/cli/weekly-summary/date-utils.ts
+++ b/packages/cli/src/cli/weekly-summary/date-utils.ts
@@ -1,0 +1,68 @@
+import dayjs from 'dayjs'
+import weekOfYear from 'dayjs/plugin/weekOfYear.js'
+import isoWeek from 'dayjs/plugin/isoWeek.js'
+
+dayjs.extend(weekOfYear)
+dayjs.extend(isoWeek)
+
+export interface DateRange {
+  since: string
+  until: string
+}
+
+/**
+ * Get the date range for the current week (Monday to today)
+ */
+export function getCurrentWeekRange(): DateRange {
+  const today = dayjs()
+  const monday = today.startOf('isoWeek')
+
+  return {
+    since: monday.format('YYYY-MM-DD'),
+    until: today.format('YYYY-MM-DD'),
+  }
+}
+
+/**
+ * Validate and format date string
+ */
+export function validateDate(dateString: string): string {
+  const date = dayjs(dateString, 'YYYY-MM-DD', true)
+
+  if (!date.isValid()) {
+    throw new Error(
+      `Invalid date format: ${dateString}. Expected format: YYYY-MM-DD`,
+    )
+  }
+
+  return date.format('YYYY-MM-DD')
+}
+
+/**
+ * Ensure the date range is valid (since <= until)
+ */
+export function validateDateRange(since: string, until: string): void {
+  const sinceDate = dayjs(since)
+  const untilDate = dayjs(until)
+
+  if (sinceDate.isAfter(untilDate)) {
+    throw new Error('Start date cannot be after end date')
+  }
+}
+
+/**
+ * Format date range for display
+ */
+export function formatDateRange(since: string, until: string): string {
+  const sinceDate = dayjs(since)
+  const untilDate = dayjs(until)
+
+  return `${sinceDate.format('YYYY-MM-DD')} to ${untilDate.format('YYYY-MM-DD')}`
+}
+
+/**
+ * Get date in git log format (ISO 8601)
+ */
+export function toGitLogFormat(date: string): string {
+  return dayjs(date).format('YYYY-MM-DDTHH:mm:ss')
+}

--- a/packages/cli/src/cli/weekly-summary/formatters.ts
+++ b/packages/cli/src/cli/weekly-summary/formatters.ts
@@ -1,0 +1,177 @@
+import { CommitInfo } from './commit-summary'
+import { PRInfo } from './pr-summary'
+
+export interface SummaryData {
+  dateRange: string
+  prs?: PRInfo[]
+  commits?: CommitInfo[]
+}
+
+/**
+ * Format output as plain text
+ */
+export function formatAsText(data: SummaryData): string {
+  const lines: string[] = []
+
+  lines.push(`=== Weekly Summary (${data.dateRange}) ===`)
+  lines.push('')
+
+  if (data.prs) {
+    lines.push(`📝 Pull Requests (${data.prs.length}):`)
+    if (data.prs.length === 0) {
+      lines.push('  No PRs found in this period')
+    } else {
+      data.prs.forEach((pr) => {
+        const stateIcon = getStateIcon(pr.state)
+        lines.push(
+          `  ${stateIcon} #${pr.number}: ${pr.title} (${pr.state}) - ${pr.author}`,
+        )
+      })
+    }
+    lines.push('')
+  }
+
+  if (data.commits) {
+    lines.push(`💾 Commits (${data.commits.length}):`)
+    if (data.commits.length === 0) {
+      lines.push('  No commits found in this period')
+    } else {
+      data.commits.slice(0, 20).forEach((commit) => {
+        // Show first 20 commits
+        const type = extractCommitType(commit.message)
+        lines.push(
+          `  • ${type ? `${type}: ` : ''}${commit.message} (${commit.hash}) - ${commit.author}`,
+        )
+      })
+
+      if (data.commits.length > 20) {
+        lines.push(`  ... and ${data.commits.length - 20} more commits`)
+      }
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Format output as markdown
+ */
+export function formatAsMarkdown(data: SummaryData): string {
+  const lines: string[] = []
+
+  lines.push(`# Weekly Summary (${data.dateRange})`)
+  lines.push('')
+
+  if (data.prs) {
+    lines.push(`## 📝 Pull Requests (${data.prs.length})`)
+    lines.push('')
+
+    if (data.prs.length === 0) {
+      lines.push('*No PRs found in this period*')
+    } else {
+      data.prs.forEach((pr) => {
+        const stateIcon = getStateIcon(pr.state)
+        lines.push(
+          `- ${stateIcon} **#${pr.number}**: ${pr.title} *(${pr.state})* - ${pr.author}`,
+        )
+      })
+    }
+    lines.push('')
+  }
+
+  if (data.commits) {
+    lines.push(`## 💾 Commits (${data.commits.length})`)
+    lines.push('')
+
+    if (data.commits.length === 0) {
+      lines.push('*No commits found in this period*')
+    } else {
+      data.commits.slice(0, 20).forEach((commit) => {
+        // Show first 20 commits
+        const type = extractCommitType(commit.message)
+        const message = type
+          ? commit.message.replace(`${type}:`, '').trim()
+          : commit.message
+        lines.push(
+          `- ${type ? `**${type}**:` : '•'} ${message} *(${commit.hash})* - ${commit.author}`,
+        )
+      })
+
+      if (data.commits.length > 20) {
+        lines.push('')
+        lines.push(`*... and ${data.commits.length - 20} more commits*`)
+      }
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Get icon for PR state
+ */
+function getStateIcon(state: string): string {
+  switch (state) {
+    case 'open':
+      return '🟢'
+    case 'merged':
+      return '🟣'
+    case 'closed':
+      return '🔴'
+    default:
+      return '•'
+  }
+}
+
+/**
+ * Extract commit type from message (feat, fix, docs, etc.)
+ */
+function extractCommitType(message: string): string | null {
+  const match = message.match(/^(\w+)(?:\(.+\))?:/)
+  return match ? match[1] : null
+}
+
+/**
+ * Generate summary statistics
+ */
+export function generateStats(data: SummaryData): string {
+  const lines: string[] = []
+
+  if (data.prs && data.prs.length > 0) {
+    const prsByState = data.prs.reduce(
+      (acc, pr) => {
+        acc[pr.state] = (acc[pr.state] || 0) + 1
+        return acc
+      },
+      {} as Record<string, number>,
+    )
+
+    lines.push('PR Statistics:')
+    Object.entries(prsByState).forEach(([state, count]) => {
+      lines.push(`  ${state}: ${count}`)
+    })
+  }
+
+  if (data.commits && data.commits.length > 0) {
+    const commitsByType = data.commits.reduce(
+      (acc, commit) => {
+        const type = extractCommitType(commit.message) || 'other'
+        acc[type] = (acc[type] || 0) + 1
+        return acc
+      },
+      {} as Record<string, number>,
+    )
+
+    if (lines.length > 0) lines.push('')
+    lines.push('Commit Statistics:')
+    Object.entries(commitsByType)
+      .sort(([, a], [, b]) => b - a)
+      .forEach(([type, count]) => {
+        lines.push(`  ${type}: ${count}`)
+      })
+  }
+
+  return lines.join('\n')
+}

--- a/packages/cli/src/cli/weekly-summary/output-handler.ts
+++ b/packages/cli/src/cli/weekly-summary/output-handler.ts
@@ -1,0 +1,63 @@
+import { writeFileSync } from 'fs'
+import { resolve } from 'path'
+
+export interface OutputOptions {
+  md?: string | boolean
+  stats?: boolean
+}
+
+/**
+ * Handle output to console or file based on options
+ */
+export function handleOutput(
+  content: string,
+  statsContent: string,
+  options: OutputOptions,
+  dateRange: { since: string; until: string },
+): void {
+  let finalOutput = content
+
+  // Add statistics if requested
+  if (options.stats && statsContent) {
+    finalOutput += '\n\n' + statsContent
+  }
+
+  // Handle markdown file output
+  if (typeof options.md === 'string') {
+    // Output to specified file
+    const filePath = resolve(options.md)
+    writeToFile(filePath, finalOutput)
+  } else if (options.md === true) {
+    // Generate default filename and save
+    const filename = generateDefaultFilename(dateRange.since, dateRange.until)
+    const filePath = resolve(filename)
+    writeToFile(filePath, finalOutput)
+  } else {
+    // Output to console
+    console.log(finalOutput)
+  }
+}
+
+/**
+ * Write content to file with error handling
+ */
+function writeToFile(filePath: string, content: string): void {
+  try {
+    writeFileSync(filePath, content, 'utf-8')
+    console.log(`📝 Weekly summary saved to: ${filePath}`)
+  } catch (error) {
+    console.error(`❌ Failed to write file: ${filePath}`)
+    console.error(
+      'Error:',
+      error instanceof Error ? error.message : String(error),
+    )
+    process.exit(1)
+  }
+}
+
+/**
+ * Generate default markdown filename based on date range
+ */
+function generateDefaultFilename(since: string, until: string): string {
+  return `weekly-summary-${since}-to-${until}.md`
+}

--- a/packages/cli/src/cli/weekly-summary/pr-summary.ts
+++ b/packages/cli/src/cli/weekly-summary/pr-summary.ts
@@ -1,0 +1,123 @@
+import { $ } from 'zx'
+import dayjs from 'dayjs'
+import isBetween from 'dayjs/plugin/isBetween.js'
+import { PR } from '../../providers/types'
+
+dayjs.extend(isBetween)
+
+export interface PRInfo extends PR {
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Get PRs within the specified date range
+ */
+export async function getPRsInRange(
+  since: string,
+  until: string,
+): Promise<PRInfo[]> {
+  try {
+    // Use GitHub CLI to get PRs with date information
+    const result =
+      await $`gh pr list --state all --json number,title,url,state,author,createdAt,updatedAt --limit 100`
+    const allPRs = JSON.parse(result.stdout) as unknown[]
+
+    const sinceDate = dayjs(since)
+    const untilDate = dayjs(until).endOf('day')
+
+    // Filter PRs by date range (using createdAt or updatedAt)
+    const filteredPRs = allPRs.filter((prData: unknown) => {
+      const pr = prData as {
+        createdAt: string
+        updatedAt: string
+      }
+      const createdAt = dayjs(pr.createdAt)
+      const updatedAt = dayjs(pr.updatedAt)
+
+      // Include PR if it was created or updated in the date range
+      return (
+        createdAt.isBetween(sinceDate, untilDate, null, '[]') ||
+        updatedAt.isBetween(sinceDate, untilDate, null, '[]')
+      )
+    })
+
+    return filteredPRs.map((prData: unknown) => {
+      const pr = prData as {
+        number: number
+        title: string
+        url: string
+        state: string
+        author: { login: string }
+        createdAt: string
+        updatedAt: string
+      }
+      return {
+        number: pr.number.toString(),
+        title: pr.title,
+        url: pr.url,
+        state: pr.state.toLowerCase() as 'open' | 'closed' | 'merged',
+        author: pr.author.login,
+        createdAt: pr.createdAt,
+        updatedAt: pr.updatedAt,
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching PRs:', error)
+    return []
+  }
+}
+
+/**
+ * Group PRs by state
+ */
+export function groupPRsByState(prs: PRInfo[]): Record<string, PRInfo[]> {
+  const groups: Record<string, PRInfo[]> = {
+    open: [],
+    merged: [],
+    closed: [],
+  }
+
+  prs.forEach((pr) => {
+    if (groups[pr.state]) {
+      groups[pr.state].push(pr)
+    }
+  })
+
+  return groups
+}
+
+/**
+ * Get PR statistics
+ */
+export function getPRStats(prs: PRInfo[]): {
+  total: number
+  byState: Record<string, number>
+  byAuthor: Record<string, number>
+} {
+  const byState: Record<string, number> = {}
+  const byAuthor: Record<string, number> = {}
+
+  prs.forEach((pr) => {
+    // Count by state
+    byState[pr.state] = (byState[pr.state] || 0) + 1
+
+    // Count by author
+    byAuthor[pr.author] = (byAuthor[pr.author] || 0) + 1
+  })
+
+  return {
+    total: prs.length,
+    byState,
+    byAuthor,
+  }
+}
+
+/**
+ * Sort PRs by update date (newest first)
+ */
+export function sortPRsByDate(prs: PRInfo[]): PRInfo[] {
+  return prs.sort((a, b) => {
+    return dayjs(b.updatedAt).valueOf() - dayjs(a.updatedAt).valueOf()
+  })
+}

--- a/packages/cli/src/cli/weekly-summary/weekly-summary.ts
+++ b/packages/cli/src/cli/weekly-summary/weekly-summary.ts
@@ -1,0 +1,135 @@
+import { Command } from 'commander'
+import ora from 'ora'
+import {
+  getCurrentWeekRange,
+  validateDate,
+  validateDateRange,
+  formatDateRange,
+} from './date-utils'
+import { getCommitsInRange } from './commit-summary'
+import { getPRsInRange } from './pr-summary'
+import {
+  formatAsText,
+  formatAsMarkdown,
+  generateStats,
+  SummaryData,
+} from './formatters'
+
+interface WeeklySummaryOptions {
+  pr?: boolean
+  commit?: boolean
+  since?: string
+  until?: string
+  md?: boolean
+  stats?: boolean
+}
+
+async function weeklySummary(options: WeeklySummaryOptions) {
+  try {
+    // Determine what to include
+    const includePRs = options.pr || (!options.pr && !options.commit)
+    const includeCommits = options.commit || (!options.pr && !options.commit)
+
+    // Determine date range
+    let since: string
+    let until: string
+
+    if (options.since || options.until) {
+      const defaultRange = getCurrentWeekRange()
+      since = options.since ? validateDate(options.since) : defaultRange.since
+      until = options.until ? validateDate(options.until) : defaultRange.until
+    } else {
+      const range = getCurrentWeekRange()
+      since = range.since
+      until = range.until
+    }
+
+    validateDateRange(since, until)
+
+    const spinner = ora('Fetching weekly summary...').start()
+
+    try {
+      const summaryData: SummaryData = {
+        dateRange: formatDateRange(since, until),
+      }
+
+      // Fetch PRs if requested
+      if (includePRs) {
+        spinner.text = 'Fetching Pull Requests...'
+        summaryData.prs = await getPRsInRange(since, until)
+      }
+
+      // Fetch commits if requested
+      if (includeCommits) {
+        spinner.text = 'Fetching commits...'
+        summaryData.commits = await getCommitsInRange(since, until)
+      }
+
+      spinner.succeed('Weekly summary generated!')
+
+      // Format and display output
+      const output = options.md
+        ? formatAsMarkdown(summaryData)
+        : formatAsText(summaryData)
+
+      console.log(output)
+
+      // Show statistics if requested
+      if (options.stats) {
+        console.log('\n' + generateStats(summaryData))
+      }
+    } catch (error) {
+      spinner.fail('Failed to generate weekly summary')
+      console.error(
+        'Error:',
+        error instanceof Error ? error.message : String(error),
+      )
+      process.exit(1)
+    }
+  } catch (error) {
+    console.error(
+      'Error:',
+      error instanceof Error ? error.message : String(error),
+    )
+    process.exit(1)
+  }
+}
+
+function setupCommander() {
+  const program = new Command()
+
+  program
+    .name('git-weekly-summary')
+    .description('Generate a summary of weekly Git activity (PRs and commits)')
+    .option('--pr', 'include Pull Requests in summary')
+    .option('--commit', 'include commits in summary')
+    .option(
+      '--since <date>',
+      'start date (YYYY-MM-DD), defaults to Monday of current week',
+    )
+    .option('--until <date>', 'end date (YYYY-MM-DD), defaults to today')
+    .option('--md', 'output in Markdown format')
+    .option('--stats', 'show additional statistics')
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ git-weekly-summary                    # Show both PRs and commits for current week
+  $ git-weekly-summary --pr              # Show only PRs for current week
+  $ git-weekly-summary --commit          # Show only commits for current week
+  $ git-weekly-summary --since 2025-08-10 --until 2025-08-16
+  $ git-weekly-summary --md              # Output in Markdown format
+  $ git-weekly-summary --pr --md --stats # PRs in Markdown with statistics
+
+Date format: YYYY-MM-DD
+Default range: Monday of current week to today
+`,
+    )
+    .action(weeklySummary)
+
+  return program
+}
+
+const program = setupCommander()
+program.parse()

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'git-create-branch': 'src/cli/create-branch/create-branch.ts',
     'git-plan-issue': 'src/cli/plan-issue/plan-issue.ts',
     'git-take-issue': 'src/cli/take-issue/take-issue.ts',
+    'git-weekly-summary': 'src/cli/weekly-summary/weekly-summary.ts',
     postinstall: 'scripts/postinstall.ts',
   },
   format: ['esm'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       ora:
         specifier: ^8.2.0
         version: 8.2.0
@@ -4251,6 +4254,12 @@ packages:
     resolution:
       {
         integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==,
+      }
+
+  dayjs@1.11.13:
+    resolution:
+      {
+        integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==,
       }
 
   debounce@1.2.1:
@@ -13163,6 +13172,8 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.1.3: {}
+
+  dayjs@1.11.13: {}
 
   debounce@1.2.1: {}
 

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -9,6 +9,7 @@ try {
   await $`git config --global alias.create-branch '!git-create-branch'`
   await $`git config --global alias.plan-issue '!git-plan-issue'`
   await $`git config --global alias.take-issue '!git-take-issue'`
+  await $`git config --global alias.weekly-summary '!git-weekly-summary'`
 
   console.log('✅ Git aliases have been set up successfully!')
   console.log('You can now use:')
@@ -19,6 +20,7 @@ try {
   console.log('  - git create-branch --jira <ticket-id>')
   console.log('  - git plan-issue <issue-id>')
   console.log('  - git take-issue <issue-id>')
+  console.log('  - git weekly-summary')
 } catch {
   console.log('⚠️  Could not set up git aliases automatically.')
 }


### PR DESCRIPTION
## 📝 Description
This pull request introduces a new `weekly-summary` command to the `git-pr-ai` toolkit. This feature allows users to generate a concise summary of their git activity over a specified period, including merged pull requests and commits.

The command is highly configurable, enabling users to:
-   Specify a date range (`--since` and `--until`).
-   Include summaries for pull requests (`--pr`) and/or commits (`--commit`).
-   Generate output in plain text or Markdown format (`--md`).
-   Include statistics about the activity (`--stats`).
-   Save the output to a file.

This is particularly useful for generating weekly reports, preparing for performance reviews, or simply keeping track of work accomplished.

## 🔄 Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 🧪 Testing
To test this new command, you can run the following:

1.  **Generate a summary for the current week:**
    ```bash
    git-pr-ai weekly-summary
    ```

2.  **Generate a summary for a specific date range and save it to a Markdown file:**
    ```bash
    git-pr-ai weekly-summary --since 2025-08-11 --until 2025-08-17 --md weekly-report.md
    ```

3.  **Generate a summary including only pull requests with stats:**
    ```bash
    git-pr-ai weekly-summary --pr --stats
    ```

## 💥 Breaking Changes
There are no breaking changes introduced in this PR.

## 📋 Checklist
- [x] Code follows the style guidelines
- [x] Self-review has been performed
- [x] Tests have been added/updated
- [x] Documentation has been updated
