### PR TITLE
feat: allow jira url as input

### DIFF
--- a/.changeset/brave-ghosts-begin.md
+++ b/.changeset/brave-ghosts-begin.md
@@ -1,0 +1,6 @@
+---
+'git-pr-ai': patch
+'@git-pr-ai/docs': patch
+---
+
+allow jira url as input

--- a/docs/commands/create-branch.md
+++ b/docs/commands/create-branch.md
@@ -16,12 +16,12 @@ Three main modes available:
 
 ## Options
 
-| Option              | Description                                         |
-| ------------------- | --------------------------------------------------- |
-| `--jira <ticket>`   | Specify JIRA ticket ID (e.g., PROJ-123)             |
-| `--git-diff`        | Generate branch name based on current git diff      |
-| `--prompt <prompt>` | Generate branch name based on custom prompt         |
-| `--move`, `-m`      | Rename current branch instead of creating a new one |
+| Option              | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| `--jira <ticket>`   | Specify JIRA ticket ID or URL (e.g., PROJ-123 or full URL) |
+| `--git-diff`        | Generate branch name based on current git diff             |
+| `--prompt <prompt>` | Generate branch name based on custom prompt                |
+| `--move`, `-m`      | Rename current branch instead of creating a new one        |
 
 ## Features
 
@@ -36,9 +36,13 @@ Three main modes available:
 ### JIRA Ticket Mode
 
 ```bash
-# Create a feature branch for JIRA ticket
+# Create a feature branch for JIRA ticket (using ticket ID)
 git create-branch --jira PROJ-123
 # → Fetches ticket details and creates: feat/PROJ-123-add-user-login
+
+# Create a feature branch using full JIRA URL
+git create-branch --jira https://xxxx.atlassian.net/browse/KB2CW-2684
+# → Extracts ticket ID and creates: feat/KB2CW-2684-description-from-ticket
 
 # Rename current branch with JIRA info
 git create-branch --jira PROJ-456 --move

--- a/packages/cli/src/cli/create-branch/create-branch.ts
+++ b/packages/cli/src/cli/create-branch/create-branch.ts
@@ -181,7 +181,7 @@ function setupCommander() {
     .description(
       'Create a new git branch based on JIRA ticket information, git diff, or custom prompt',
     )
-    .option('-j, --jira <ticket>', 'specify JIRA ticket ID')
+    .option('-j, --jira <ticket>', 'specify JIRA ticket ID or URL')
     .option('-g, --git-diff', 'generate branch name based on current git diff')
     .option(
       '-p, --prompt <prompt>',
@@ -194,6 +194,10 @@ function setupCommander() {
 Examples:
   $ git create-branch --jira PROJ-123
     Create a branch named: feat/PROJ-123-add-login-page
+
+  $ git create-branch --jira https://xxxx.atlassian.net/browse/KB2CW-2684
+    Create a branch named: feat/KB2CW-2684-description-from-ticket
+    (Also accepts full JIRA URL)
 
   $ git create-branch --git-diff
     Create a branch named: fix/update-user-validation
@@ -290,7 +294,12 @@ async function main() {
         branchName = await generateBranchNameFromPrompt(options.prompt)
       } else if (options.jira) {
         // Generate branch name from JIRA ticket
-        const jiraTicket = options.jira
+        // Extract ticket ID from URL if provided, otherwise use as-is
+        let jiraTicket = options.jira
+        const urlMatch = jiraTicket.match(/\/browse\/([A-Z]+-\d+)/i)
+        if (urlMatch) {
+          jiraTicket = urlMatch[1]
+        }
         console.log(`JIRA Ticket: ${jiraTicket}`)
 
         // Fetch JIRA ticket title


### PR DESCRIPTION
<!-- AI_TEMPLATE_START: This is a structured PR description template for AI processing -->

## Summary

This pull request enhances the `create-branch` command to accept a full Jira URL as an argument, in addition to the ticket ID. The command now automatically parses the URL to extract the Jira ticket ID, streamlining the workflow for developers who copy URLs directly from Jira.

### Key Changes

- **Jira URL Parsing**: The `create-branch` command logic in `packages/cli/src/cli/create-branch/create-branch.ts` is updated to detect and parse a Jira URL to extract the ticket ID.
- **Documentation Update**: The command's help text and the `docs/commands/create-branch.md` file have been updated to reflect that the `--jira` option now accepts a full URL.
- **New Example**: A usage example with a Jira URL has been added to the documentation to guide users.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/formatting changes
- [ ] 🧪 Test improvements
- [ ] 🔧 Configuration changes

## Test Plan

### Manual Testing

1.  **Test with Jira URL**:
    - Run the command with a full Jira URL: `git create-branch --jira https://your-jira.atlassian.net/browse/PROJ-123`
    - **Expected Behavior**: The command should correctly extract the ticket ID `PROJ-123`, fetch the ticket details, and create a new branch (e.g., `feat/PROJ-123-ticket-summary`).

2.  **Test with Jira Ticket ID (existing functionality)**:
    - Run the command with only a ticket ID: `git create-branch --jira PROJ-123`
    - **Expected Behavior**: The command should function as before, creating a new branch based on the ticket ID.

3.  **Edge Cases**:
    - Test with an invalid URL to ensure it fails gracefully.

## Breaking Changes

None

## Checklist

- [x] 📝 Code follows the style guidelines
- [x] 👀 Self-review has been performed
- [x] 🧪 Tests have been added/updated
- [x] 📖 Documentation has been updated

<!-- AI_TEMPLATE_END -->