### PR TITLE
feat: add no verify commit option

### DIFF
--- a/.changeset/ai-commit-no-verify.md
+++ b/.changeset/ai-commit-no-verify.md
@@ -1,0 +1,5 @@
+---
+"git-pr-ai": minor
+---
+
+Add `--no-verify` option to `git ai-commit` to skip git commit hooks (passes `--no-verify` to `git commit`)

--- a/packages/cli/src/cli/ai-commit/ai-commit.ts
+++ b/packages/cli/src/cli/ai-commit/ai-commit.ts
@@ -91,7 +91,10 @@ async function generateCommitMessages(
   }
 }
 
-async function createCommit(commitMessage: string): Promise<void> {
+async function createCommit(
+  commitMessage: string,
+  noVerify = false,
+): Promise<void> {
   try {
     // Check if there are staged changes
     const stagedResult = await $`git diff --cached --quiet`.exitCode
@@ -106,7 +109,11 @@ async function createCommit(commitMessage: string): Promise<void> {
 
     // Create the commit
     // Use stdio: 'inherit' to preserve TTY for hooks
-    await $({ stdio: 'inherit' })`git commit -m ${commitMessage}`
+    if (noVerify) {
+      await $({ stdio: 'inherit' })`git commit --no-verify -m ${commitMessage}`
+    } else {
+      await $({ stdio: 'inherit' })`git commit -m ${commitMessage}`
+    }
   } catch (error) {
     console.error('Failed to create commit')
     throw error
@@ -119,6 +126,7 @@ async function createCommit(commitMessage: string): Promise<void> {
 async function runJiraCommitFlow(
   commitType: string,
   jiraOption: string | boolean,
+  noVerify = false,
 ): Promise<void> {
   const jiraContext = await resolveJiraContext(jiraOption)
   if (!jiraContext) {
@@ -128,13 +136,14 @@ async function runJiraCommitFlow(
   }
 
   const commitMessage = buildJiraCommitMessage(commitType, jiraContext)
-  await createCommit(commitMessage)
+  await createCommit(commitMessage, noVerify)
 }
 
 async function runAiCommitFlow(
   commitType: string,
   prompt?: string,
   nonInteractive = false,
+  noVerify = false,
 ): Promise<void> {
   const gitDiff = await getGitDiff()
   const commitMessages = await generateCommitMessages(
@@ -160,7 +169,7 @@ async function runAiCommitFlow(
     )
   }
 
-  await createCommit(selectedMessage)
+  await createCommit(selectedMessage, noVerify)
 }
 
 function setupCommander() {
@@ -183,6 +192,7 @@ function setupCommander() {
     )
     .option('--non-interactive', 'run without local interactive prompts')
     .option('--ci', 'alias of --non-interactive')
+    .option('--no-verify', 'skip git commit hooks (passes --no-verify to git)')
     .addHelpText(
       'after',
       `
@@ -208,6 +218,9 @@ Examples:
     Auto-select commit type/message without local prompts
     (Commit type is chosen by AI when --type is not provided)
 
+  $ git ai-commit --no-verify
+    Skip git commit hooks (pre-commit, commit-msg)
+
 Prerequisites:
   - Git provider CLI must be installed and authenticated: GitHub CLI (gh) or GitLab CLI (glab)
   - AI provider must be configured in ~/.git-pr-ai/.git-pr-ai.json
@@ -228,6 +241,7 @@ async function main() {
         type?: string
         nonInteractive?: boolean
         ci?: boolean
+        verify?: boolean
       },
     ) => {
       try {
@@ -261,12 +275,15 @@ async function main() {
           console.log(`Non-interactive mode: commit type will be chosen by AI`)
         }
 
+        // Commander sets `verify: false` when --no-verify is passed
+        const noVerify = options.verify === false
+
         if (options.jira) {
-          await runJiraCommitFlow(commitType, options.jira)
+          await runJiraCommitFlow(commitType, options.jira, noVerify)
           return
         }
 
-        await runAiCommitFlow(commitType, prompt, nonInteractive)
+        await runAiCommitFlow(commitType, prompt, nonInteractive, noVerify)
       } catch (error: unknown) {
         const errorMessage =
           error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Summary

Adds a `--no-verify` option to the `git ai-commit` command, allowing users to skip git commit hooks (such as `pre-commit` and `commit-msg`) when creating a commit. When the flag is set, the underlying `git commit` call is invoked with `--no-verify`.

### Key Changes

- Added `--no-verify` CLI option to `git ai-commit`
- Threaded a `noVerify` flag through `createCommit`, `runJiraCommitFlow`, and `runAiCommitFlow`
- When `--no-verify` is passed, `createCommit` runs `git commit --no-verify` instead of `git commit`
- Added help text and usage example for the new option
- Added a changeset (`minor` bump)

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 Style/formatting changes
- [ ] 🧪 Test improvements
- [ ] 🔧 Configuration changes

## Test Plan

### Manual Testing

- Stage some changes, then run `git ai-commit --no-verify` in a repo with a failing/blocking `pre-commit` hook → commit succeeds and hooks are skipped
- Run `git ai-commit` (without the flag) → hooks run as before (default behavior unchanged)
- Run `git ai-commit --jira <ticket> --no-verify` → Jira commit flow also skips hooks

## Breaking Changes

None

## Checklist

- [x] 📝 Code follows style guidelines
- [x] 👀 Self-review performed
- [ ] 🧪 Tests added/updated
- [x] 📖 Documentation updated
