### PR TITLE
fix(open-pr): correctly detect fork workflow with origin and upstream remotes

### DIFF
--- a/.changeset/fix-fork-remote-detection.md
+++ b/.changeset/fix-fork-remote-detection.md
@@ -1,0 +1,14 @@
+---
+"git-pr-ai": patch
+---
+
+fix(open-pr): correctly detect fork workflow when both origin and upstream remotes exist
+
+Previously, `gh repo view` (without an explicit repo argument) would resolve to the upstream org repo and return `isFork: false`, causing the owner filter in PR lookup to reject the existing PR and failing to create new PRs with the correct `owner:branch` head ref.
+
+`getRepoContext` now uses a three-step resolution:
+1. Parse `current` from `git remote get-url origin` directly
+2. If an `upstream` remote exists and differs from `origin`, treat as fork workflow
+3. Fall back to `gh repo view <current>` (explicit repo) for GitHub-registered forks without a local upstream remote
+
+Also fixes `git update-pr-desc` to pass `prDetails.url` instead of `prDetails.number` to `gh pr edit`, so the target repo is always resolved unambiguously.

--- a/packages/cli/src/cli/update-pr-desc/runner.test.ts
+++ b/packages/cli/src/cli/update-pr-desc/runner.test.ts
@@ -68,7 +68,10 @@ describe('runUpdateDescriptionWithExecutionMode', () => {
 
     expect(executeAIWithOutput).toHaveBeenCalledTimes(1)
     expect(executeAICommand).not.toHaveBeenCalled()
-    expect(updateDescription).toHaveBeenCalledWith('new description', '456')
+    expect(updateDescription).toHaveBeenCalledWith(
+      'new description',
+      'https://example.com/pr/456',
+    )
   })
 
   it('uses interactive executor in normal mode', async () => {

--- a/packages/cli/src/cli/update-pr-desc/runner.ts
+++ b/packages/cli/src/cli/update-pr-desc/runner.ts
@@ -35,7 +35,7 @@ export async function runUpdateDescriptionWithExecutionMode({
         yolo,
         commandName: 'updatePrDesc',
       })
-      await updateDescription(description, prDetails.number)
+      await updateDescription(description, prDetails.url)
       spinner.succeed('PR description generated successfully')
     } catch (error) {
       spinner.fail('Failed to generate PR description')

--- a/packages/cli/src/providers/github.test.ts
+++ b/packages/cli/src/providers/github.test.ts
@@ -29,22 +29,11 @@ describe('GitHubProvider', () => {
       if (command === 'git rev-parse --abbrev-ref HEAD') {
         return { stdout: 'feat/fork-branch\n' }
       }
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
-        return {
-          stdout: JSON.stringify({
-            nameWithOwner: 'alice/fork-repo',
-            owner: { login: 'alice' },
-            name: 'fork-repo',
-            isFork: true,
-            parent: {
-              nameWithOwner: 'org/main-repo',
-              owner: { login: 'org' },
-              name: 'main-repo',
-            },
-          }),
-        }
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
       }
       if (
         command.includes(
@@ -75,22 +64,11 @@ describe('GitHubProvider', () => {
       if (command === 'git rev-parse --abbrev-ref HEAD') {
         return { stdout: 'feat/fork-branch\n' }
       }
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
-        return {
-          stdout: JSON.stringify({
-            nameWithOwner: 'alice/fork-repo',
-            owner: { login: 'alice' },
-            name: 'fork-repo',
-            isFork: true,
-            parent: {
-              nameWithOwner: 'org/main-repo',
-              owner: { login: 'org' },
-              name: 'main-repo',
-            },
-          }),
-        }
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
       }
       if (
         command.includes(
@@ -142,22 +120,11 @@ describe('GitHubProvider', () => {
       if (command === 'git rev-parse --abbrev-ref HEAD') {
         return { stdout: 'feat/fork-branch\n' }
       }
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
-        return {
-          stdout: JSON.stringify({
-            nameWithOwner: 'alice/fork-repo',
-            owner: { login: 'alice' },
-            name: 'fork-repo',
-            isFork: true,
-            parent: {
-              nameWithOwner: 'org/main-repo',
-              owner: { login: 'org' },
-              name: 'main-repo',
-            },
-          }),
-        }
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
       }
       if (
         command.includes(
@@ -209,9 +176,13 @@ describe('GitHubProvider', () => {
       if (command === 'git rev-parse --abbrev-ref HEAD') {
         return { stdout: 'feat/fork-branch\n' }
       }
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
+      }
+      if (command.includes('gh pr list')) {
         throw new Error('gh auth failed')
       }
       throw new Error(`Unexpected command: ${command}`)
@@ -227,22 +198,11 @@ describe('GitHubProvider', () => {
       if (command === 'git rev-parse --abbrev-ref HEAD') {
         return { stdout: 'feat/fork-branch\n' }
       }
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
-        return {
-          stdout: JSON.stringify({
-            nameWithOwner: 'alice/fork-repo',
-            owner: { login: 'alice' },
-            name: 'fork-repo',
-            isFork: true,
-            parent: {
-              nameWithOwner: 'org/main-repo',
-              owner: { login: 'org' },
-              name: 'main-repo',
-            },
-          }),
-        }
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
       }
       if (
         command.includes(
@@ -322,22 +282,11 @@ describe('GitHubProvider', () => {
   it('getPRDetails with number tries upstream first, then current repo', async () => {
     const provider = new GitHubProvider()
     const executedCommands = setupCommandMock((command) => {
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
-        return {
-          stdout: JSON.stringify({
-            nameWithOwner: 'alice/fork-repo',
-            owner: { login: 'alice' },
-            name: 'fork-repo',
-            isFork: true,
-            parent: {
-              nameWithOwner: 'org/main-repo',
-              owner: { login: 'org' },
-              name: 'main-repo',
-            },
-          }),
-        }
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
       }
       if (
         command ===
@@ -368,29 +317,22 @@ describe('GitHubProvider', () => {
 
     expect(details.owner).toBe('alice')
     expect(details.repo).toBe('fork-repo')
-    expect(executedCommands[1]).toContain('--repo org/main-repo')
-    expect(executedCommands[2]).toContain('--repo alice/fork-repo')
+    expect(
+      executedCommands.some((c) => c.includes('--repo org/main-repo')),
+    ).toBe(true)
+    expect(
+      executedCommands.some((c) => c.includes('--repo alice/fork-repo')),
+    ).toBe(true)
   })
 
   it('getPRDetails with number rethrows non-not-found errors during repo probing', async () => {
     const provider = new GitHubProvider()
     const executedCommands = setupCommandMock((command) => {
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
-        return {
-          stdout: JSON.stringify({
-            nameWithOwner: 'alice/fork-repo',
-            owner: { login: 'alice' },
-            name: 'fork-repo',
-            isFork: true,
-            parent: {
-              nameWithOwner: 'org/main-repo',
-              owner: { login: 'org' },
-              name: 'main-repo',
-            },
-          }),
-        }
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
       }
       if (
         command ===
@@ -428,9 +370,18 @@ describe('GitHubProvider', () => {
   it('createPR uses web flow by default', async () => {
     const provider = new GitHubProvider()
     const executedCommands = setupCommandMock((command) => {
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        throw new Error('no such remote')
+      }
+      if (command === 'gh repo view alice/repo --json isFork,parent') {
+        return { stdout: JSON.stringify({ isFork: false, parent: null }) }
+      }
       if (
         command ===
-        'gh pr create --title feat: add login --base main --head feat/add-login --web'
+        'gh pr create --repo alice/repo --title feat: add login --base main --head feat/add-login --web'
       ) {
         return { stdout: '' }
       }
@@ -441,7 +392,7 @@ describe('GitHubProvider', () => {
 
     expect(
       executedCommands.includes(
-        'gh pr create --title feat: add login --base main --head feat/add-login --web',
+        'gh pr create --repo alice/repo --title feat: add login --base main --head feat/add-login --web',
       ),
     ).toBe(true)
   })
@@ -449,9 +400,18 @@ describe('GitHubProvider', () => {
   it('createPR skips web flow when web option is false', async () => {
     const provider = new GitHubProvider()
     const executedCommands = setupCommandMock((command) => {
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        throw new Error('no such remote')
+      }
+      if (command === 'gh repo view alice/repo --json isFork,parent') {
+        return { stdout: JSON.stringify({ isFork: false, parent: null }) }
+      }
       if (
         command ===
-        'gh pr create --title feat: add login --body "" --base main --head feat/add-login'
+        'gh pr create --repo alice/repo --title feat: add login --body "" --base main --head feat/add-login'
       ) {
         return { stdout: '' }
       }
@@ -464,7 +424,34 @@ describe('GitHubProvider', () => {
 
     expect(
       executedCommands.includes(
-        'gh pr create --title feat: add login --body "" --base main --head feat/add-login',
+        'gh pr create --repo alice/repo --title feat: add login --body "" --base main --head feat/add-login',
+      ),
+    ).toBe(true)
+  })
+
+  it('createPR targets upstream repo and uses owner:branch head ref in fork workflow', async () => {
+    const provider = new GitHubProvider()
+    const executedCommands = setupCommandMock((command) => {
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
+      }
+      if (
+        command ===
+        'gh pr create --repo org/main-repo --title feat: add login --base main --head alice:feat/add-login --web'
+      ) {
+        return { stdout: '' }
+      }
+      throw new Error(`Unexpected command: ${command}`)
+    })
+
+    await provider.createPR('feat: add login', 'feat/add-login', 'main')
+
+    expect(
+      executedCommands.includes(
+        'gh pr create --repo org/main-repo --title feat: add login --base main --head alice:feat/add-login --web',
       ),
     ).toBe(true)
   })
@@ -476,22 +463,11 @@ describe('GitHubProvider', () => {
       if (command === 'git rev-parse --abbrev-ref HEAD') {
         return { stdout: 'feat/fork-branch\n' }
       }
-      if (
-        command === 'gh repo view --json nameWithOwner,owner,name,isFork,parent'
-      ) {
-        return {
-          stdout: JSON.stringify({
-            nameWithOwner: 'alice/fork-repo',
-            owner: { login: 'alice' },
-            name: 'fork-repo',
-            isFork: true,
-            parent: {
-              nameWithOwner: 'org/main-repo',
-              owner: { login: 'org' },
-              name: 'main-repo',
-            },
-          }),
-        }
+      if (command === 'git remote get-url origin') {
+        return { stdout: 'https://github.com/alice/fork-repo.git\n' }
+      }
+      if (command === 'git remote get-url upstream') {
+        return { stdout: 'https://github.com/org/main-repo.git\n' }
       }
       if (
         command.includes(

--- a/packages/cli/src/providers/github.test.ts
+++ b/packages/cli/src/providers/github.test.ts
@@ -325,7 +325,7 @@ describe('GitHubProvider', () => {
     ).toBe(true)
   })
 
-  it('getPRDetails with number rethrows non-not-found errors during repo probing', async () => {
+  it('getPRDetails with number rethrows non-not-found errors from pr view', async () => {
     const provider = new GitHubProvider()
     const executedCommands = setupCommandMock((command) => {
       if (command === 'git remote get-url origin') {

--- a/packages/cli/src/providers/github.ts
+++ b/packages/cli/src/providers/github.ts
@@ -102,54 +102,93 @@ export class GitHubProvider implements GitProvider {
   }
 
   /**
-   * Load current repository + fork parent context from GitHub.
-   * This provides both the current repo identity and possible upstream target,
-   * which is required for deterministic cross-repo PR resolution.
+   * Parse a GitHub remote URL (HTTPS or SSH) into owner/repo parts.
+   */
+  private parseGitHubRemoteUrl(url: string): GitHubRepoRef | null {
+    const match = url.match(/github\.com[:/]([^/]+)\/([^/\s.]+?)(?:\.git)?\s*$/)
+    if (!match) return null
+    const [, owner, name] = match
+    return { owner, name, fullName: `${owner}/${name}` }
+  }
+
+  /**
+   * Load current repository + fork parent context.
+   *
+   * Resolution order:
+   * 1. Parse `current` from the `origin` git remote (reliable regardless of how
+   *    `gh` resolves its "base repo" when multiple remotes exist).
+   * 2. If an `upstream` remote exists and points to a different repo, treat this
+   *    as a fork workflow with that repo as the parent.
+   * 3. Otherwise query `gh repo view <current>` explicitly (not bare `gh repo view`,
+   *    which may resolve to the wrong remote) to detect forks registered on GitHub
+   *    that don't have a local `upstream` remote configured.
    */
   private async getRepoContext(): Promise<GitHubRepoContext> {
-    const result =
-      await $`gh repo view --json nameWithOwner,owner,name,isFork,parent`
-    const repoData = JSON.parse(result.stdout) as {
-      nameWithOwner: string
-      owner: { login: string }
-      name: string
-      isFork: boolean
-      parent?: {
-        nameWithOwner?: string
-        owner?: { login: string }
-        name?: string
-      } | null
+    // Step 1: derive current repo from origin remote
+    let current: GitHubRepoRef | null = null
+    try {
+      const originResult = await $`git remote get-url origin`
+      current = this.parseGitHubRemoteUrl(originResult.stdout.trim())
+    } catch {
+      // origin may not exist in some setups; fall through to gh
     }
 
-    const current: GitHubRepoRef = {
-      owner: repoData.owner.login,
-      name: repoData.name,
-      fullName: repoData.nameWithOwner,
+    if (!current) {
+      // Fallback for repos without a named origin remote
+      const result = await $`gh repo view --json nameWithOwner,owner,name`
+      const d = JSON.parse(result.stdout) as {
+        nameWithOwner: string
+        owner: { login: string }
+        name: string
+      }
+      current = {
+        owner: d.owner.login,
+        name: d.name,
+        fullName: d.nameWithOwner,
+      }
     }
 
-    let parent: GitHubRepoRef | null = null
-    if (repoData.parent?.nameWithOwner) {
-      const [owner = '', name = ''] = repoData.parent.nameWithOwner.split('/')
-      if (owner && name) {
+    // Step 2: explicit upstream remote → definitive fork detection
+    try {
+      const upstreamResult = await $`git remote get-url upstream`.quiet()
+      const parent = this.parseGitHubRemoteUrl(upstreamResult.stdout.trim())
+      if (parent && parent.fullName !== current.fullName) {
+        return { current, isFork: true, parent }
+      }
+    } catch {
+      // No upstream remote configured
+    }
+
+    // Step 3: query GitHub API for forks that don't have a local upstream remote
+    try {
+      const result =
+        await $`gh repo view ${current.fullName} --json isFork,parent`
+      const repoData = JSON.parse(result.stdout) as {
+        isFork: boolean
+        parent?: {
+          nameWithOwner?: string
+          owner?: { login: string }
+          name?: string
+        } | null
+      }
+
+      let parent: GitHubRepoRef | null = null
+      if (repoData.parent?.nameWithOwner) {
+        const [owner = '', name = ''] = repoData.parent.nameWithOwner.split('/')
+        if (owner && name) {
+          parent = { owner, name, fullName: repoData.parent.nameWithOwner }
+        }
+      } else if (repoData.parent?.owner?.login && repoData.parent?.name) {
         parent = {
-          owner,
-          name,
-          fullName: repoData.parent.nameWithOwner,
+          owner: repoData.parent.owner.login,
+          name: repoData.parent.name,
+          fullName: `${repoData.parent.owner.login}/${repoData.parent.name}`,
         }
       }
-    } else if (repoData.parent?.owner?.login && repoData.parent?.name) {
-      // Keep a fallback path because different hosts/versions may not always return nameWithOwner.
-      parent = {
-        owner: repoData.parent.owner.login,
-        name: repoData.parent.name,
-        fullName: `${repoData.parent.owner.login}/${repoData.parent.name}`,
-      }
-    }
 
-    return {
-      current,
-      isFork: repoData.isFork,
-      parent,
+      return { current, isFork: repoData.isFork, parent }
+    } catch {
+      return { current, isFork: false, parent: null }
     }
   }
 
@@ -317,11 +356,23 @@ export class GitHubProvider implements GitProvider {
     const spinner = ora('Creating Pull Request...').start()
     const useWeb = options.web !== false
 
+    const repoContext = await this.getRepoContext()
+    const targetRepo =
+      repoContext.isFork && repoContext.parent
+        ? repoContext.parent
+        : repoContext.current
+
+    // In fork workflows, gh requires "<fork-owner>:<branch>" to identify the head branch.
+    const headRef =
+      repoContext.isFork && repoContext.parent
+        ? `${repoContext.current.owner}:${branch}`
+        : branch
+
     if (useWeb) {
-      await $`gh pr create --title ${title} --base ${baseBranch} --head ${branch} --web`
+      await $`gh pr create --repo ${targetRepo.fullName} --title ${title} --base ${baseBranch} --head ${headRef} --web`
     } else {
       // `zx` runs `gh` in non-interactive mode, so we must provide a body explicitly.
-      await $`gh pr create --title ${title} --body "" --base ${baseBranch} --head ${branch}`
+      await $`gh pr create --repo ${targetRepo.fullName} --title ${title} --body "" --base ${baseBranch} --head ${headRef}`
     }
     spinner.succeed('Pull Request created successfully!')
   }

--- a/packages/cli/src/providers/github.ts
+++ b/packages/cli/src/providers/github.ts
@@ -127,7 +127,7 @@ export class GitHubProvider implements GitProvider {
     // Step 1: derive current repo from origin remote
     let current: GitHubRepoRef | null = null
     try {
-      const originResult = await $`git remote get-url origin`
+      const originResult = await $`git remote get-url origin`.quiet()
       current = this.parseGitHubRemoteUrl(originResult.stdout.trim())
     } catch {
       // origin may not exist in some setups; fall through to gh
@@ -187,7 +187,11 @@ export class GitHubProvider implements GitProvider {
       }
 
       return { current, isFork: repoData.isFork, parent }
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (!msg.includes('Could not resolve') && !msg.includes('not found')) {
+        throw err
+      }
       return { current, isFork: false, parent: null }
     }
   }

--- a/packages/cli/src/test-utils/zx-mock.ts
+++ b/packages/cli/src/test-utils/zx-mock.ts
@@ -27,11 +27,20 @@ export function setupCommandMock(
     const command = stringifyCommand(args)
     executedCommands.push(command)
 
+    let promise: Promise<MockCommandResult>
     try {
-      return Promise.resolve(handler(command))
+      promise = Promise.resolve(handler(command))
     } catch (error) {
-      return Promise.reject(error)
+      promise = Promise.reject(error)
     }
+
+    // zx's ProcessPromise supports chaining `.quiet()`; mirror it so mocked
+    // commands using `$`...`.quiet()` resolve through the same handler.
+    const processPromise = promise as Promise<MockCommandResult> & {
+      quiet: () => Promise<MockCommandResult>
+    }
+    processPromise.quiet = () => processPromise
+    return processPromise
   })
 
   return executedCommands


### PR DESCRIPTION
## Summary

Fixes incorrect fork detection in `git open-pr` when both `origin` (fork) and `upstream` (parent) remotes are configured. Previously, bare `gh repo view` could resolve to the upstream org repo and return `isFork: false`, causing existing PRs to be missed and new PRs to be created with the wrong head ref format.

### Key Changes

- **`getRepoContext` rewritten with three-step resolution**: (1) parse `current` from `git remote get-url origin` directly, (2) detect fork via local `upstream` remote if it differs from `origin`, (3) fall back to `gh repo view <explicit-repo>` for GitHub-registered forks without a local upstream remote
- **Added `parseGitHubRemoteUrl` helper**: parses both HTTPS and SSH remote URLs into `owner/repo` components
- **`createPR` now targets the correct repo**: passes `--repo <upstream>` and uses `owner:branch` head ref format in fork workflows
- **Fixed `update-pr-desc`**: passes `prDetails.url` instead of `prDetails.number` to `gh pr edit` for unambiguous repo resolution
- **Updated tests**: replaced `gh repo view` mocks with `git remote get-url origin/upstream` mocks; added new test for fork PR creation

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

### Manual Testing

- [ ] `git open-pr` in a repo with both `origin` (fork) and `upstream` (parent) correctly finds the existing PR in the parent repo
- [ ] `git open-pr` in a repo without an `upstream` remote runs cleanly with no error output
- [ ] `git open-pr` creating a new PR in a fork uses `owner:branch` head ref and targets the upstream repo
- [ ] All 184 unit tests pass

## Breaking Changes

None

## Checklist

- [x] 📝 Code follows style guidelines
- [x] 👀 Self-review performed
- [x] 🧪 Tests added/updated
- [x] 📖 Documentation updated
